### PR TITLE
Remove validation to solve validation errors

### DIFF
--- a/src/Resources/config/validation.xml
+++ b/src/Resources/config/validation.xml
@@ -14,19 +14,6 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping
         http://symfony.com/schema/dic/services/constraint-mapping-1.0.xsd">
 
-    <class name="FOS\CommentBundle\Model\Comment">
-
-        <property name="body">
-            <constraint name="NotBlank">
-                <option name="message">Please enter a message</option>
-            </constraint>
-            <constraint name="Length">
-                <option name="min">3</option>
-                <option name="minMessage">The message is too short|The message is too short</option>
-            </constraint>
-        </property>
-    </class>
-
     <class name="FOS\CommentBundle\Model\Vote">
         <constraint name="Callback">isVoteValid</constraint>
     </class>


### PR DESCRIPTION
With the validation, the rendering of the form is broken:

`Symfony\Component\Form\FormRenderer::searchAndRenderBlock(): Argument #1 ($view) must be of type Symfony\Component\Form\FormView, Symfony\Component\Form\Form given, called in /home/docker/current/var/cache/dev/twig/c9/c915c7d9a353f77e1216462db79b4a77042f7a76cb6b5e6fc747934ce1fc4b13.php on line 89`